### PR TITLE
"Fix" bot-spy launcher script

### DIFF
--- a/bot2-lcm-utils/CMakeLists.txt
+++ b/bot2-lcm-utils/CMakeLists.txt
@@ -11,23 +11,10 @@ add_subdirectory(python)
 
 # bot-spy
 set(script_name bot-spy)
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
-    "#!/bin/sh\n"
-    "CLASSPATH=`PKG_CONFIG_PATH=PKG_CONFIG_PATH:${CMAKE_INSTALL_PREFIX}/lib/pkgconfig pkg-config --variable=classpath lcm-java`\n"
-    "for d in . .. ../.. ../../.. ../../../.. \"${CMAKE_INSTALL_PREFIX}\"; do\n"
-    #    "for d in \"${CMAKE_INSTALL_PREFIX}\"; do\n"
-    "  if [ -d $d/share/java ]; then\n"
-    "    jd=$d/share/java\n"
-    "    echo Checking $jd\n"
-    "    for f in $jd/lcmtypes_*.jar $jd/lcmspy_plugins_*.jar; do\n"
-    "      if [ -e $f ]; then\n"
-    "        echo \"   Found $f\"\n"
-    "        CLASSPATH=\$CLASSPATH:\$f\n"
-    "      fi\n"
-    "    done\n"
-    "  fi\n"
-    "done\n"
-    "exec java -ea -cp \$CLASSPATH lcm.spy.Spy $*\n")
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/${script_name}.sh.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${script_name}
+  @ONLY)
 
 # install it...
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)

--- a/bot2-lcm-utils/bot-spy.sh.in
+++ b/bot2-lcm-utils/bot-spy.sh.in
@@ -1,0 +1,15 @@
+#!/bin/sh
+for d in . .. ../.. ../../.. ../../../.. "@CMAKE_INSTALL_PREFIX@"; do
+  if [ -d $d/share/java ]; then
+    jd=$d/share/java
+    echo Checking $jd
+    for f in $jd/lcmtypes_*.jar $jd/lcmspy_plugins_*.jar; do
+      if [ -e $f ]; then
+        echo "   Found $f"
+        CLASSPATH="${CLASSPATH:+$CLASSPATH:}$f"
+      fi
+    done
+  fi
+done
+export CLASSPATH
+exec lcm-spy


### PR DESCRIPTION
Rewrite bot-spy launcher script to add its own class paths, then hand off to the updated (lcm-proj/lcm#143) lcm-spy that sets up the necessary class paths for LCM itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/libbot2/2)
<!-- Reviewable:end -->
