### PR TITLE
add features to accept external pmd orders for `bot-procman-sheriff`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You will also need to manually install LCM from <https://lcm-proj.github.io/>.
 git clone --branch drake https://github.com/RobotLocomotion/libbot2.git
 mkdir libbot2-build
 cd libbot2-build
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake -DCMAKE_INSTALL_PREFIX=/path/to/libbot2/install ../libbot2
 make install
 ```

--- a/bot2-procman/README.md
+++ b/bot2-procman/README.md
@@ -57,6 +57,7 @@ or with `-l`, but `--lone-ranger` is cooler.
 git clone --branch drake https://github.com/RobotLocomotion/libbot2.git
 mkdir libbot2-build
 cd libbot2-build
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake -DCMAKE_INSTALL_PREFIX=/path/to/libbot2/install -DWITH_BOT_PROCMAN=ON ../libbot2
 make install
 ```

--- a/bot2-procman/doc/content/comms.md
+++ b/bot2-procman/doc/content/comms.md
@@ -68,6 +68,7 @@ LCM Channel | Message type | Description
 ------------|--------------|-------------
 `PMD_DISOCVER` | [discovery_t](\ref procman_lcm_discovery_t) | When received, the deputy replies by transmitting its state on `PMD_INFO2`.
 `PMD_ORDERS2` | [orders2_t](\ref procman_lcm_orders2_t) | When received, the deputy checks if the orders are targeted for it.  If not, or if the timestamp on the orders differs significantly from the deputy's system clock, then it ignores the message.  Otherwise, the deputy modifies its state to achieve the state indicated by the orders.  This may involve creating, starting, and stopping commands.
+`EXTERNAL_PMD_ORDERS2` | [orders2_t](\ref procman_lcm_orders2_t) | Mostly same with `PMD_ORDERS2`, but this is for ordering commands externally, not from gui.
 
 # Sheriff {#procman_comms_sheriff}
 

--- a/bot2-procman/python/procman-sheriff.glade
+++ b/bot2-procman/python/procman-sheriff.glade
@@ -114,6 +114,15 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkCheckMenuItem" id="enable_external_pmd_orders_cmi">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">_Accept External Orders</property>
+                        <property name="use_underline">True</property>
+                        <signal name="toggled" handler="on_enable_external_pmd_orders_cmi_toggled" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkMenuItem" id="spawn_deputy_mi">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/bot2-procman/python/src/bot_procman/sheriff.py
+++ b/bot2-procman/python/src/bot_procman/sheriff.py
@@ -57,6 +57,35 @@ def _now_utime():
     return int(time.time() * 1000000)
 
 
+def _orders_to_orders2_t(dep_orders):
+    new_orders = orders2_t()
+    new_orders.utime = dep_orders.utime
+    new_orders.host = dep_orders.host
+    new_orders.sheriff_name = dep_orders.sheriff_name
+    new_orders.num_options = 0
+    new_orders.option_names = []
+    new_orders.option_values = []
+    new_orders.ncmds = dep_orders.ncmds
+    for cmd_index, cmd_order in enumerate(dep_orders.cmds):
+        cmd_msg = dep_orders.cmds[cmd_index]
+        new_cmd_msg = sheriff_cmd2_t()
+        new_cmd_msg.cmd = command2_t()
+        new_cmd_msg.cmd.exec_str = cmd_msg.name
+        new_cmd_msg.cmd.command_name = cmd_msg.nickname
+        new_cmd_msg.cmd.group = cmd_msg.group
+        new_cmd_msg.cmd.auto_respawn = cmd_msg.auto_respawn
+        new_cmd_msg.cmd.stop_signal = DEFAULT_STOP_SIGNAL
+        new_cmd_msg.cmd.stop_time_allowed = DEFAULT_STOP_TIME_ALLOWED
+        new_cmd_msg.cmd.num_options = 0
+        new_cmd_msg.cmd.option_names = []
+        new_cmd_msg.cmd.option_values = []
+        new_cmd_msg.desired_runid = cmd_msg.desired_runid
+        new_cmd_msg.force_quit = cmd_msg.force_quit
+        new_cmd_msg.sheriff_id = cmd_msg.sheriff_id
+        new_orders.cmds.append(new_cmd_msg)
+    return new_orders
+
+
 # Command status - trying to start
 TRYING_TO_START = "Starting (Command Sent)"
 
@@ -433,6 +462,27 @@ class SheriffDeputy(object):
                 if old_status != new_status:
                     status_changes.append((cmd, old_status, new_status))
         return status_changes
+    
+    def _update_from_external_deputy_orders2(self, orders_msg):
+        status_changes = []
+        for cmd_msg in orders_msg.cmds:
+            if cmd_msg.sheriff_id in self._commands:
+                cmd = self._commands[cmd_msg.sheriff_id]
+                old_status = cmd.status()
+            else:
+                _warn("New commands from external orders are not supported.")
+                _warn("Ignoring to add thecommand %s" % cmd_msg.name)
+                continue
+            cmd._update_from_cmd_order2(cmd_msg)
+            new_status = cmd.status()
+            if old_status != new_status:
+                status_changes.append((cmd, old_status, new_status))
+        updated_ids = set([cmd_msg.sheriff_id for cmd_msg in orders_msg.cmds])
+        for cmd in self._commands.values():
+            if cmd.sheriff_id not in updated_ids:
+                _warn("Removing commands from external orders are not supported.")
+                _warn("Ignoring the removal of %s" % cmd.name)
+        return status_changes
 
     def _add_command(self, newcmd):
         assert newcmd.sheriff_id != 0
@@ -594,8 +644,11 @@ class Sheriff(object):
         self._lcm.subscribe("PMD_INFO2", self._on_pmd_info2)
         self._lcm.subscribe("PMD_ORDERS", self._on_pmd_orders)
         self._lcm.subscribe("PMD_ORDERS2", self._on_pmd_orders2)
+        self._lcm.subscribe("EXTERNAL_PMD_ORDERS", self._on_external_pmd_orders)
+        self._lcm.subscribe("EXTERNAL_PMD_ORDERS2", self._on_external_pmd_orders2)
         self._deputies = {}
         self._is_observer = False
+        self._enable_external_pmd_orders = False
         self._name = (platform.node() + ":" + str(os.getpid()) + ":"
                       + str(_now_utime()))
 
@@ -844,33 +897,30 @@ class Sheriff(object):
 
     def _on_pmd_orders(self, _, data):
         dep_orders = orders_t.decode(data)
-
-        new_orders = orders2_t()
-        new_orders.utime = dep_orders.utime
-        new_orders.host = dep_orders.host
-        new_orders.sheriff_name = dep_orders.sheriff_name
-        new_orders.num_options = 0
-        new_orders.option_names = []
-        new_orders.option_values = []
-        new_orders.ncmds = dep_orders.ncmds
-        for cmd_index, cmd_order in enumerate(dep_orders.cmds):
-            cmd_msg = dep_orders.cmds[cmd_index]
-            new_cmd_msg = sheriff_cmd2_t()
-            new_cmd_msg.cmd = command2_t()
-            new_cmd_msg.cmd.exec_str = cmd_msg.name
-            new_cmd_msg.cmd.command_name = cmd_msg.nickname
-            new_cmd_msg.cmd.group = cmd_msg.group
-            new_cmd_msg.cmd.auto_respawn = cmd_msg.auto_respawn
-            new_cmd_msg.cmd.stop_signal = DEFAULT_STOP_SIGNAL
-            new_cmd_msg.cmd.stop_time_allowed = DEFAULT_STOP_TIME_ALLOWED
-            new_cmd_msg.cmd.num_options = 0
-            new_cmd_msg.cmd.option_names = []
-            new_cmd_msg.cmd.option_values = []
-            new_cmd_msg.desired_runid = cmd_msg.desired_runid
-            new_cmd_msg.force_quit = cmd_msg.force_quit
-            new_cmd_msg.sheriff_id = cmd_msg.sheriff_id
-            new_orders.cmds.append(new_cmd_msg)
+        new_orders = _orders_to_orders2_t(dep_orders)
         self._handle_orders2_t(new_orders)
+
+    def _handle_external_orders2_t(self, orders_msg):
+        if self._is_observer:
+            # ignore external orders in observer mode
+            _warn("Ignoring external orders in Observer mode")
+            return
+        if not self._enable_external_pmd_orders:
+            _warn("Ignoring external orders because enable_external_pmd_orders is False")
+            return
+        deputy = self._get_or_make_deputy(orders_msg.host)
+        status_changes = deputy._update_from_external_deputy_orders2(orders_msg)
+        self._maybe_emit_status_change_signals(deputy, status_changes)
+        self.send_orders()
+
+    def _on_external_pmd_orders2(self, _, data):
+        orders_msg = orders2_t.decode(data)
+        self._handle_external_orders2_t(orders_msg)
+
+    def _on_external_pmd_orders(self, _, data):
+        dep_orders = orders_t.decode(data)
+        new_orders = _orders_to_orders2_t(dep_orders)
+        self._handle_external_orders2_t(new_orders)
 
     def __get_free_sheriff_id(self):
         id_to_try = random.randint(0, (1 << 31) - 1)
@@ -1120,6 +1170,14 @@ class Sheriff(object):
         spec.stop_signal = cmd.stop_signal
         spec.stop_time_allowed = cmd.stop_time_allowed
         return self.add_command(spec)
+
+    def set_enable_external_pmd_orders(self, enable):
+        """Set whether the sheriff should accept external pmd orders.
+
+        @param enable True if the sheriff should enable external pmd orders,
+        False if it should ignore them.
+        """
+        self._enable_external_pmd_orders = enable
 
     def set_observer(self, is_observer):
         """Set the sheriff into observation mode, or remove it from

--- a/bot2-procman/python/src/bot_procman/sheriff_gtk/sheriff_gtk.py
+++ b/bot2-procman/python/src/bot_procman/sheriff_gtk/sheriff_gtk.py
@@ -777,8 +777,8 @@ Options:
   -l, --lone-ranger   Automatically run a deputy within the sheriff process
                       This deputy terminates with the sheriff, along with
                       all the commands it hosts.
-  
-  -a, --accept-external-orders
+
+  -e, --enable_external_pmd_orders
                       Only valid in lone ranger mode.
                       Runs in accept external orders mode on startup. This
                       allows the sheriff to accept external orders, not from 

--- a/bot2-procman/python/src/bot_procman/sheriff_gtk/sheriff_gtk.py
+++ b/bot2-procman/python/src/bot_procman/sheriff_gtk/sheriff_gtk.py
@@ -142,6 +142,7 @@ class SheriffGtk(object):
 
         # options menu
         self.is_observer_cmi = self.builder.get_object("is_observer_cmi")
+        self.enable_external_pmd_orders_cmi = self.builder.get_object("enable_external_pmd_orders_cmi")
         self.spawn_deputy_mi = self.builder.get_object("spawn_deputy_mi")
         self.terminate_spawned_deputy_mi = self.builder.get_object(
             "terminate_spawned_deputy_mi")
@@ -348,6 +349,14 @@ class SheriffGtk(object):
 
         if self.is_observer_cmi != is_observer:
             self.is_observer_cmi.set_active(is_observer)
+
+    def set_enable_external_pmd_orders(self, enable_external_pmd_orders):
+        self.sheriff.set_enable_external_pmd_orders(enable_external_pmd_orders)
+
+        self._update_menu_item_sensitivities()
+
+        if self.enable_external_pmd_orders_cmi != enable_external_pmd_orders:
+            self.enable_external_pmd_orders_cmi.set_active(enable_external_pmd_orders)
 
     def run_script(self, menuitem, script, script_done_action=None):
         self.script_done_action = script_done_action
@@ -576,6 +585,9 @@ class SheriffGtk(object):
     def on_is_observer_cmi_toggled(self, menu_item):
         self.set_observer(menu_item.get_active())
 
+    def on_enable_external_pmd_orders_cmi_toggled(self, menu_item):
+        self.set_enable_external_pmd_orders(menu_item.get_active())
+
     def on_spawn_deputy_mi_activate(self, *args):
         print("Spawn deputy!")
         self._terminate_spawned_deputy()
@@ -765,6 +777,12 @@ Options:
   -l, --lone-ranger   Automatically run a deputy within the sheriff process
                       This deputy terminates with the sheriff, along with
                       all the commands it hosts.
+  
+  -a, --accept-external-orders
+                      Only valid in lone ranger mode.
+                      Runs in accept external orders mode on startup. This
+                      allows the sheriff to accept external orders, not from 
+                      the GUI.
 
   -n, --no-gui        Runs in headless mode (no GUI).
 
@@ -792,8 +810,8 @@ named script once the config file is loaded.
 
 def main():
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'hlon', [
-            'help', 'lone-ranger', 'on-script-complete=', 'no-gui', 'observer'
+        opts, args = getopt.getopt(sys.argv[1:], 'hleon', [
+            'help', 'lone-ranger', 'enable_external_pmd_orders', 'on-script-complete=', 'no-gui', 'observer'
         ])
     except getopt.GetoptError:
         usage()
@@ -803,10 +821,13 @@ def main():
     use_gui = True
     script_done_action = None
     observer = False
+    enable_external_pmd_orders = False
 
     for optval, argval in opts:
         if optval in ['-l', '--lone-ranger']:
             spawn_deputy = True
+        elif optval in ['-e', '--enable_external_pmd_orders']:
+            enable_external_pmd_orders = True
         elif optval in ['-n', '--no-gui']:
             use_gui = False
         elif optval in ['-o', '--observer']:
@@ -842,6 +863,9 @@ def main():
         if spawn_deputy:
             print("Lone ranger mode and observer mode are mutually exclusive.")
             sys.exit(1)
+        if enable_external_pmd_orders:
+            print("Enabling external pmd orders is only valid in the lone ranger mode.")
+            sys.exit(1)
 
     lc = LCM()
 
@@ -860,6 +884,8 @@ def main():
             gui.set_observer(True)
         if spawn_deputy:
             gui.on_spawn_deputy_mi_activate()
+            if enable_external_pmd_orders:
+                gui.set_enable_external_pmd_orders(True)
         if cfg is not None:
             gui.load_config(cfg)
             gui.load_save_dir = os.path.dirname(args[0])


### PR DESCRIPTION
## Objective
Accepting external pmd orders while running `bot-procman-sheriff -l`.

## Background
The current `bot-procman-sheriff -l` does not accept any external command orders. Introducing new subscribers for the external orders enable us to apply user intent using different interfaces, not on the gui.

## Key Changes
This pr includes:
- The new gui option called `Accept External Orders` and the corresponding arguments.
- The new lcm channels named `EXTERNAL_PMD_ORDERS` and `EXTERNAL_PMD_ORDERS2`.
- README fix.

### Other comments
- This pr does not support adding or removing orders externally. It can be dangerous to add / remove commands and start them by external messages as users like.
- Overwriting `PMD_ORDER2` messages in the other module can work. However, it would not be practical since the `bot-procman-sheriff -l` publishes both `PMD_ODERS2` and `PMD_INFO2` at 1 Hz.
- There is a clear objective to introduce this feature, but unfortunately it should not be shared here since it includes a certain extent of internal information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/libbot2/26)
<!-- Reviewable:end -->
